### PR TITLE
chore: add reusable plugin workflow

### DIFF
--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -74,3 +74,4 @@ jobs:
             - uses: fastify/github-action-merge-dependabot@v3
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  target: minor

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -2,6 +2,11 @@ name: Plugin CI
 
 on:
     workflow_call:
+        inputs:
+            generate-coverage:
+                description: 'Set to true to generate coverage and send to Coveralls.'
+                required: false
+                type: boolean
 
 jobs:
     test:
@@ -32,6 +37,7 @@ jobs:
 
             - name: Coveralls Parallel
               id: coveralls-parallel
+              if: inputs.generate-coverage == true
               continue-on-error: true
               uses: coverallsapp/github-action@master
               with:
@@ -43,14 +49,14 @@ jobs:
               id: coveralls-trigger
               # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
               # when continue-on-error failed, outcome is failure and conclusion is success
-              if: steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
+              if: inputs.generate-coverage == true && steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
               run: |
                   echo "::set-output name=COVERALLS_TRIGGER::failure"
 
     coverage:
         needs: test
         runs-on: ubuntu-latest
-        if: needs.test.outputs.COVERALLS != 'failure'
+        if: inputs.generate-coverage == true && needs.test.outputs.COVERALLS != 'failure'
         steps:
             - name: Coveralls Finished
               uses: coverallsapp/github-action@master

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -7,6 +7,10 @@ jobs:
     test:
         runs-on: ${{ matrix.os }}
 
+        # output.COVERALLS is a variable to determine whether we should post to coveralls when all parallel test finish
+        outputs:
+            COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}
+
         strategy:
             matrix:
                 node-version: [10, 12, 14, 16]

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -1,0 +1,66 @@
+name: Plugin CI
+
+on:
+    workflow_call:
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                node-version: [10, 12, 14, 16]
+                os: [macos-latest, ubuntu-latest, windows-latest]
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Use Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+
+            - name: Install Dependencies
+              run: npm i --ignore-scripts
+
+            - name: Run Tests
+              run: npm test
+
+            - name: Coveralls Parallel
+              id: coveralls-parallel
+              continue-on-error: true
+              uses: coverallsapp/github-action@master
+              with:
+                  github-token: ${{ secrets.github_token }}
+                  parallel: true
+                  flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
+
+            - name: Should Trigger coverallsapp/github-action
+              id: coveralls-trigger
+              # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
+              # when continue-on-error failed, outcome is failure and conclusion is success
+              if: steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
+              run: |
+                  echo "::set-output name=COVERALLS_TRIGGER::failure"
+
+    coverage:
+        needs: test
+        runs-on: ubuntu-latest
+        if: needs.test.outputs.COVERALLS != 'failure'
+        steps:
+            - name: Coveralls Finished
+              uses: coverallsapp/github-action@master
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  parallel-finished: true
+
+    automerge:
+        needs: test
+        permissions:
+            pull-requests: write
+            contents: write
+        runs-on: ubuntu-latest
+        steps:
+            - uses: fastify/github-action-merge-dependabot@v3
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -1,77 +1,77 @@
 name: Plugin CI
 
 on:
-    workflow_call:
-        inputs:
-            generate-coverage:
-                description: 'Set to true to generate coverage and send to Coveralls.'
-                required: false
-                type: boolean
+  workflow_call:
+    inputs:
+      generate-coverage:
+        description: 'Set to true to generate coverage and send to Coveralls.'
+        required: false
+        type: boolean
 
 jobs:
-    test:
-        runs-on: ${{ matrix.os }}
+  test:
+    runs-on: ${{ matrix.os }}
 
-        # output.COVERALLS is a variable to determine whether we should post to coveralls when all parallel test finish
-        outputs:
-            COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}
+    # output.COVERALLS is a variable to determine whether we should post to coveralls when all parallel test finish
+    outputs:
+      COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}
 
-        strategy:
-            matrix:
-                node-version: [10, 12, 14, 16]
-                os: [macos-latest, ubuntu-latest, windows-latest]
+    strategy:
+      matrix:
+        node-version: [10, 12, 14, 16]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
-        steps:
-            - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Use Node.js
-              uses: actions/setup-node@v2
-              with:
-                  node-version: ${{ matrix.node-version }}
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
-            - name: Install Dependencies
-              run: npm i --ignore-scripts
+      - name: Install Dependencies
+        run: npm i --ignore-scripts
 
-            - name: Run Tests
-              run: npm test
+      - name: Run Tests
+        run: npm test
 
-            - name: Coveralls Parallel
-              id: coveralls-parallel
-              if: inputs.generate-coverage == true
-              continue-on-error: true
-              uses: coverallsapp/github-action@master
-              with:
-                  github-token: ${{ secrets.github_token }}
-                  parallel: true
-                  flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
+      - name: Coveralls Parallel
+        id: coveralls-parallel
+        if: inputs.generate-coverage == true
+        continue-on-error: true
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel: true
+          flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
 
-            - name: Should Trigger coverallsapp/github-action
-              id: coveralls-trigger
-              # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
-              # when continue-on-error failed, outcome is failure and conclusion is success
-              if: inputs.generate-coverage == true && steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
-              run: |
-                  echo "::set-output name=COVERALLS_TRIGGER::failure"
+      - name: Should Trigger coverallsapp/github-action
+        id: coveralls-trigger
+        # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
+        # when continue-on-error failed, outcome is failure and conclusion is success
+        if: inputs.generate-coverage == true && steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
+        run: |
+          echo "::set-output name=COVERALLS_TRIGGER::failure"
 
-    coverage:
-        needs: test
-        runs-on: ubuntu-latest
-        if: inputs.generate-coverage == true && needs.test.outputs.COVERALLS != 'failure'
-        steps:
-            - name: Coveralls Finished
-              uses: coverallsapp/github-action@master
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  parallel-finished: true
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    if: inputs.generate-coverage == true && needs.test.outputs.COVERALLS != 'failure'
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
-    automerge:
-        needs: test
-        permissions:
-            pull-requests: write
-            contents: write
-        runs-on: ubuntu-latest
-        steps:
-            - uses: fastify/github-action-merge-dependabot@v3
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  target: minor
+  automerge:
+    needs: test
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ jobs:
 
 ## Inputs
 
-| Input Name        | Required | Type    | Default | Description                                             |
-| ----------------- | -------- | ------- | ------- | ------------------------------------------------------- |
-| generate-coverage | false    | boolean | false   | Set to true to generate coverage and send to Coveralls. |
+| Input Name          | Required | Type    | Default | Description                                               |
+| ------------------- | -------- | ------- | ------- | --------------------------------------------------------- |
+| `generate-coverage` | false    | boolean | `false` | Set to `true` to generate coverage and send to Coveralls. |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ A reusable workflow is called by using the `uses` keyword in another workflow:
 name: CI
 
 on:
-    push:
-        paths-ignore:
-            - 'docs/**'
-            - '*.md'
-    pull_request:
-        paths-ignore:
-            - 'docs/**'
-            - '*.md'
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 jobs:
-    call-reuseable-workflow:
-        uses: fastify/workflows/.github/workflows/plugins-ci.yml@v1
-        with:
-            generate-coverage: true
+  call-reuseable-workflow:
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v1
+    with:
+      generate-coverage: true
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# workflows
-Reusable workflows for use in the Fastify organization
+# Workflows
+
+Reusable workflows for use in the Fastify organization.
+
+## Intro
+
+GitHub [introduced reusable workflows](https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/) on 2021-11-29 which, as the name suggests, are workflows that can be referenced across the entirety of GitHub.
+
+For more information, including limitations, [see the GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows).
+
+## Usage
+
+A reusable workflow is called by using the `uses` keyword in another workflow:
+
+```yml
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+            - master
+        paths-ignore:
+            - 'docs/**'
+            - '*.md'
+    pull_request:
+        branches:
+            - main
+            - master
+        paths-ignore:
+            - 'docs/**'
+            - '*.md'
+
+jobs:
+    call-reuseable-workflow:
+        uses: fastify/workflows/.github/workflows/plugins-ci.yml@v1
+```
+
+## Acknowledgements
+
+This project is kindly sponsored by:
+
+-   [Yeovil District Hospital NHS Foundation Trust](https://yeovilhospital.co.uk/)
+
+## License
+
+Licensed under [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ on:
 jobs:
     call-reuseable-workflow:
         uses: fastify/workflows/.github/workflows/plugins-ci.yml@v1
+        with:
+            generate-coverage: true
 ```
+
+## Inputs
+
+| Input Name        | Required | Type    | Default | Description                                             |
+| ----------------- | -------- | ------- | ------- | ------------------------------------------------------- |
+| generate-coverage | false    | boolean | false   | Set to true to generate coverage and send to Coveralls. |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,10 @@ name: CI
 
 on:
     push:
-        branches:
-            - main
-            - master
         paths-ignore:
             - 'docs/**'
             - '*.md'
     pull_request:
-        branches:
-            - main
-            - master
         paths-ignore:
             - 'docs/**'
             - '*.md'


### PR DESCRIPTION
Created a basic reusable GitHub Action workflow that can be used across all of the plugins in the Fastify org.

Also integrates changes to coveralls actions as mentioned in https://github.com/fastify/fastify/issues/3328, and the latest fastify/github-action-merge-dependabot version.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
