### PR TITLE
feat: add `auto-merge-exclude` workflow input

### DIFF
--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -2,6 +2,12 @@ name: Plugin CI - MySQL
 
 on:
   workflow_call:
+    inputs:
+      auto-merge-excludes:
+        description: 'A comma separated list of packages that you do not want to be auto-merged.'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   test:
@@ -49,5 +55,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
+          excludes: ${{ inputs.auto-merge-excludes }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -6,6 +6,7 @@ on:
       auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
+        default: 'fastify'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -6,7 +6,6 @@ on:
       auto-merge-excludes:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
-        default: ''
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -3,7 +3,7 @@ name: Plugin CI - MySQL
 on:
   workflow_call:
     inputs:
-      auto-merge-excludes:
+      auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
         type: string
@@ -54,6 +54,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
-          excludes: ${{ inputs.auto-merge-excludes }}
+          exclude: ${{ inputs.auto-merge-exclude }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -6,6 +6,7 @@ on:
       auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
+        default: 'fastify'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -2,6 +2,12 @@ name: Plugin CI - PostgreSQL
 
 on:
   workflow_call:
+    inputs:
+      auto-merge-excludes:
+        description: 'A comma separated list of packages that you do not want to be auto-merged.'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   test:
@@ -60,5 +66,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
+          excludes: ${{ inputs.auto-merge-excludes }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -6,7 +6,6 @@ on:
       auto-merge-excludes:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
-        default: ''
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -3,7 +3,7 @@ name: Plugin CI - PostgreSQL
 on:
   workflow_call:
     inputs:
-      auto-merge-excludes:
+      auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
         type: string
@@ -65,6 +65,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
-          excludes: ${{ inputs.auto-merge-excludes }}
+          exclude: ${{ inputs.auto-merge-exclude }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -3,6 +3,11 @@ name: Plugin CI
 on:
   workflow_call:
     inputs:
+      auto-merge-excludes:
+        description: 'A comma separated list of packages that you do not want to be auto-merged.'
+        required: false
+        default: ''
+        type: string
       lint:
         description: 'Set to true to run linting scripts.'
         required: false
@@ -57,5 +62,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
+          excludes: ${{ inputs.auto-merge-excludes }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -3,7 +3,7 @@ name: Plugin CI
 on:
   workflow_call:
     inputs:
-      auto-merge-excludes:
+      auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
         type: string
@@ -61,6 +61,6 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
-          excludes: ${{ inputs.auto-merge-excludes }}
+          exclude: ${{ inputs.auto-merge-exclude }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -6,7 +6,6 @@ on:
       auto-merge-excludes:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
-        default: ''
         type: string
       lint:
         description: 'Set to true to run linting scripts.'

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -6,6 +6,7 @@ on:
       auto-merge-exclude:
         description: 'A comma separated list of packages that you do not want to be auto-merged.'
         required: false
+        default: 'fastify'
         type: string
       lint:
         description: 'Set to true to run linting scripts.'

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
 | Input Name            | Required | Type    | Default | Description                                                                        |
 | --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude` | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `auto-merge-exclude`  | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
 | `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
 | Input Name            | Required | Type    | Default | Description                                                                        |
 | --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude`  | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `auto-merge-exclude`  | false    | string  | `fastify`      | Provide a comma separated list of packages that you do not want to be auto-merged. |
 | `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Included in this repo is a [basic workflow](.github/workflows/plugins-ci.yml) fo
 
 By setting the `lint` option to `true` when using the [basic workflow](.github/workflows/plugins-ci.yml) the CI will first run the linter job once.
 
-
-__Example:__ running the linter job first with the [basic workflow](.github/workflows/plugins-ci.yml)
+**Example:** running the linter job first with the [basic workflow](.github/workflows/plugins-ci.yml)
 
 ```yml
 name: CI
@@ -58,6 +57,13 @@ jobs:
     with:
       lint: true
 ```
+
+## Inputs
+
+| Input Name            | Required | Type    | Default | Description                                                                        |
+| --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
+| `auto-merge-excludes` | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
 | Input Name            | Required | Type    | Default | Description                                                                        |
 | --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-excludes` | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `auto-merge-exclude` | false    | string  | ``      | Provide a comma separated list of packages that you do not want to be auto-merged. |
 | `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
 
 ## Acknowledgements


### PR DESCRIPTION
Not 100% on if an empty string is acceptable as the default for `excludes` for [fastify/github-action-merge-dependabot](https://github.com/fastify/github-action-merge-dependabot), which is what [string inputs fall back to](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs).

Tackles https://github.com/fastify/workflows/pull/11#issuecomment-1046287233

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
