### PR TITLE
feat: automated release

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  workflow_call:
+    inputs:
+      semver:
+        description: "The semver to use"
+        required: true
+        type: string
+      tag:
+        description: "The npm tag"
+        required: false
+        type: string
+    secrets:
+      ORG_NPM_TOKEN:
+        required: true
+      ORG_MEMBER_OPTIC_TOKEN:
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: nearform/optic-release-automation-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.ORG_NPM_TOKEN }}
+          optic-token: ${{ secrets.ORG_MEMBER_OPTIC_TOKEN }}
+          semver: ${{ inputs.semver }}
+          npm-tag: ${{ inputs.tag }}
+          commit-message: "Bumped {version}"

--- a/examples/how-to-use-release-package.yml
+++ b/examples/how-to-use-release-package.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: "The semver to use"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      tag:
+        description: "The npm tag"
+        required: false
+        default: "latest"
+  pull_request:
+    types: [closed]
+
+jobs:
+  call-reuseable-workflow:
+    uses: fastify/workflows/.github/workflows/release-package@automated-release
+    with:
+      semver: ${{ github.event.inputs.semver }}
+      tag: ${{ github.event.inputs.commit-message }}
+    secrets:
+      ORG_NPM_TOKEN: ${{ secrets.ORG_NPM_TOKEN }}
+      ORG_MEMBER_OPTIC_TOKEN: ${{ secrets[format('ORG_OPTIC_TOKEN_{0}', github.actor)] }}

--- a/examples/how-to-use-release-package.yml
+++ b/examples/how-to-use-release-package.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   call-reuseable-workflow:
-    uses: fastify/workflows/.github/workflows/release-package@automated-release
+    uses: fastify/workflows/.github/workflows/release-package.yml@automated-release
     with:
       semver: ${{ github.event.inputs.semver }}
       tag: ${{ github.event.inputs.commit-message }}


### PR DESCRIPTION
Adding this setup to support automated releases.

I'm introducing the `examples/` directory to add many copy-paste files to avoid the README "pollution" that may become unreadable.

Todos:

- [ ] docs/readme


Tested here:
https://github.com/fastify/fastify-accepts/blob/3bc0b49a0ea23884808761418331138390f052ec/.github/workflows/release.yml