### PR TITLE
fix: mysql and postgres workflow

### DIFF
--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         node-version: [14, 16, 18]
         os: [ubuntu-latest]
-        db: [mysql:8.0]
+        db: ['mysql:8.0']
 
     services:
       mysql:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         node-version: [14, 16, 18]
         os: [ubuntu-latest]
-        db: [postgres:11-alpine]
+        db: ['postgres:11-alpine']
 
     services:
       postgres:


### PR DESCRIPTION
Invalid syntax because `:` is a syntax. YAML cannot identify should it be a `key-value` pair inside `[ ]`
It requires a explicit `quote` in this case.