### PR TITLE
chore: remove git credentials after checkout

### DIFF
--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -22,11 +22,13 @@ jobs:
     permissions:
       contents: read
     steps:
-        - name: Check out repo
-          uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
-        - name: Dependency review
-          uses: actions/dependency-review-action@v1
+      - name: Dependency review
+        uses: actions/dependency-review-action@v1
 
   linter:
     name: Lint Code
@@ -41,6 +43,8 @@ jobs:
       - name: Check out repo
         if: ${{ inputs.lint == true}}
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         if: ${{ inputs.lint == true}}
@@ -82,6 +86,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -22,11 +22,13 @@ jobs:
     permissions:
       contents: read
     steps:
-        - name: Check out repo
-          uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
-        - name: Dependency review
-          uses: actions/dependency-review-action@v1
+      - name: Dependency review
+        uses: actions/dependency-review-action@v1
 
   linter:
     name: Lint Code
@@ -41,6 +43,8 @@ jobs:
       - name: Check out repo
         if: ${{ inputs.lint == true}}
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         if: ${{ inputs.lint == true}}
@@ -83,6 +87,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -22,11 +22,13 @@ jobs:
     permissions:
       contents: read
     steps:
-        - name: Check out repo
-          uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
-        - name: Dependency review
-          uses: actions/dependency-review-action@v1
+      - name: Dependency review
+        uses: actions/dependency-review-action@v1
 
   linter:
     name: Lint Code
@@ -41,6 +43,8 @@ jobs:
       - name: Check out repo
         if: ${{ inputs.lint == true}}
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         if: ${{ inputs.lint == true}}
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
See option description at https://github.com/actions/checkout#usage.

We don't use git in any `run` commands after checking out the repo, so best to just remove the git credentials for security sake.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
