### PR TITLE
feat: support install pnpm

### DIFF
--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d # v2.2.2
         if: ${{ inputs.pnpm == true}}
         with:
           version: ${{ inputs.pnpm-version}}
@@ -100,7 +100,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d # v2.2.2
         if: ${{ inputs.pnpm == true}}
         with:
           version: ${{ inputs.pnpm-version}}

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -13,6 +13,16 @@ on:
         required: false
         default: false
         type: boolean
+      pnpm:
+        description: 'Set to true to install pnpm.'
+        required: false
+        default: false
+        type: boolean
+      pnpm-version:
+        description: 'install pnpm version'
+        required: false
+        default: '7.4.0'
+        type: string
 
 jobs:
   dependency-review:
@@ -54,6 +64,12 @@ jobs:
         with:
           node-version: 16
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.2
+        if: ${{ inputs.pnpm == true}}
+        with:
+          version: ${{ inputs.pnpm-version}}
+
       - name: Install dependencies
         if: ${{ inputs.lint == true}}
         run: npm i --ignore-scripts
@@ -82,6 +98,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.2
+        if: ${{ inputs.pnpm == true}}
+        with:
+          version: ${{ inputs.pnpm-version}}
 
       - name: Install dependencies
         run: npm i --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
 | `auto-merge-exclude` | false    | string  | `fastify` | Provide a comma separated list of packages that you do not want to be auto-merged. |
 | `lint`               | false    | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
 | `pnpm`               | false    | boolean | `false`   | Set to `true` to install `pnpm`                                                    |
-| `pnpm-version`       | false    | string  | `7.4.0`   | When `pnpm` is true, the installed version of pnpm                                 |
+| `pnpm-version`       | false    | string  | `7.4.0`   | When `pnpm` is true, the version of pnpm to install                                |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ jobs:
 
 ## Inputs
 
-| Input Name            | Required | Type    | Default | Description                                                                        |
-| --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude`  | false    | string  | `fastify`      | Provide a comma separated list of packages that you do not want to be auto-merged. |
-| `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| Input Name           | Required | Type    | Default   | Description                                                                        |
+| -------------------- | -------- | ------- | --------- | ---------------------------------------------------------------------------------- |
+| `auto-merge-exclude` | false    | string  | `fastify` | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `lint`               | false    | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| `pnpm`               | false    | boolean | `false`   | Set to `true` to install `pnpm`                                                    |
+| `pnpm-version`       | false    | string  | `7.4.0`   | When `pnpm` is true, the installed version of pnpm                                 |
 
 ## Acknowledgements
 


### PR DESCRIPTION
The main reason for submitting this PR is that I was developing `fastify-plugin` and found that the CI was failing when doing unit tests. I pinpointed this and found that it was caused by `fastify-workflows` not supporting pnpm. (see: https://github.com/BlackHole1/fastify-reqid/pull/2 / https://github.com/BlackHole1/fastify-reqid/runs/7105341768?check_suite_focus=true)

> In the future, we can also add `yarn`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
