### PR TITLE
feat: support coveralls

### DIFF
--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      coveralls:
+        description: 'enable coveralls'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   dependency-review:
@@ -88,6 +93,26 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Coveralls Parallel
+        if: inputs.coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.os }}-${{ matrix.node-version }}
+          parallel: true
+
+  coveralls-finish:
+    name: Coveralls Finished Report
+    if: inputs.coveralls
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true
 
   automerge:
     name: Automerge Dependabot PRs

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ jobs:
 
 ## Inputs
 
-| Input Name            | Required | Type    | Default | Description                                                                        |
-| --------------------- | -------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude`  | false    | string  | `fastify`      | Provide a comma separated list of packages that you do not want to be auto-merged. |
-| `lint`                | false    | boolean | `false` | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| Input Name           | Required | Type    | Default   | Description                                                                        |
+| -------------------- | -------- | ------- | --------- | ---------------------------------------------------------------------------------- |
+| `auto-merge-exclude` | false    | string  | `fastify` | Provide a comma separated list of packages that you do not want to be auto-merged. |
+| `lint`               | false    | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| `coveralls`          | false    | boolean | `false`   | enable coveralls.                                                                  |
 
 ## Acknowledgements
 


### PR DESCRIPTION
When I was writing the plugin, I discovered that this workflow does not support coveralls.
I have implemented this part in the [fastify-workflows-community](https://github.com/BlackHole1/fastify-workflows-community).
Now I want to make the official workflows support this feature as well.
> Because I found that some official plugins removed coveralls support when migrating to these workflows (just like: https://github.com/fastify/fastify-helmet/pull/182/files). Now they can come back. 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
