### PR TITLE
fix: remove `needs`

### DIFF
--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -62,7 +62,6 @@ jobs:
 
   linter:
     name: Lint Code
-    needs: license-check
     if: >
       !failure() &&
       !cancelled() &&
@@ -91,7 +90,6 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
-    needs: linter
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -62,7 +62,6 @@ jobs:
 
   linter:
     name: Lint Code
-    needs: license-check
     if: >
       !failure() &&
       !cancelled() &&
@@ -89,7 +88,6 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
-    needs: linter
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -62,7 +62,6 @@ jobs:
 
   linter:
     name: Lint Code
-    needs: license-check
     if: >
       !failure() &&
       !cancelled() &&
@@ -89,7 +88,6 @@ jobs:
 
   test:
     name: Test
-    needs: linter
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
See https://github.com/fastify/session/pull/104

If the `license-checker` and `linter` jobs are not enabled via inputs then it skips the `test` job.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
