### PR TITLE
fix invalid definition in `plugins-ci` and `plugins-ci-redis`

### DIFF
--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -99,8 +99,8 @@ jobs:
         node-version: [14, 16, 18, 20]
         db: [5, 6, 7]
         exclude:
-          os: windows-latest
-          node-version: 14
+          - os: windows-latest
+            node-version: 14
     services:
       redis:
         image: redis:${{ matrix.db }}

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -101,8 +101,8 @@ jobs:
         node-version: [14, 16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
-          os: windows-latest
-          node-version: 14
+          - os: windows-latest
+            node-version: 14
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
fix:
- #80


Example of usage:
```yaml
strategy:
  matrix:
    os: [macos-latest, windows-latest]
    version: [12, 14, 16]
    environment: [staging, production]
    exclude:
      - os: macos-latest
        version: 12
        environment: production
      - os: windows-latest
        version: 16
runs-on: ${{ matrix.os }}
```

from [Github Actions docs - Using a matrix for your jobs - Excluding matrix configurations](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations)