### PR TITLE
fail-fast input setting

### DIFF
--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
       auto-merge-exclude:
-        description: 'A semicolon seperated list of packages that you do not want to be auto-merged.'
+        description: 'A semicolon separated list of packages that you do not want to be auto-merged.'
         required: false
         default: 'fastify'
         type: string
+      fail-fast:
+        description: 'Set to false to disable the fail-fast strategy.'
+        required: false
+        default: true
+        type: boolean
       license-check:
-        description: 'Check licenses'
+        description: 'Check licenses.'
         required: false
         type: boolean
         default: false
       license-check-allowed-additional:
-        description: 'A semicolon seperated list of additional licenses to allow.'
+        description: 'A semicolon separated list of additional licenses to allow.'
         required: false
         type: string
         default: ''
@@ -22,11 +27,6 @@ on:
         description: 'Set to true to run linting scripts.'
         required: false
         default: false
-        type: boolean
-      fail-fast:
-        description: 'Set the fail-fast strategey setting.'
-        required: false
-        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail-fast:
+        description: 'Set the fail-fast strategey setting.'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dependency-review:
@@ -97,6 +102,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         node-version: [14, 16, 18, 20]
         os: [ubuntu-latest]

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
       auto-merge-exclude:
-        description: 'A semicolon seperated list of packages that you do not want to be auto-merged.'
+        description: 'A semicolon separated list of packages that you do not want to be auto-merged.'
         required: false
         default: 'fastify'
         type: string
+      fail-fast:
+        description: 'Set to false to disable the fail-fast strategy.'
+        required: false
+        default: true
+        type: boolean
       license-check:
         description: 'Check licenses.'
         required: false
         type: boolean
         default: false
       license-check-allowed-additional:
-        description: 'A semicolon seperated list of additional licenses to allow.'
+        description: 'A semicolon separated list of additional licenses to allow.'
         required: false
         type: string
         default: ''
@@ -22,11 +27,6 @@ on:
         description: 'Set to true to run linting scripts.'
         required: false
         default: false
-        type: boolean
-      fail-fast:
-        description: 'Set the fail-fast strategey setting.'
-        required: false
-        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail-fast:
+        description: 'Set the fail-fast strategey setting.'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dependency-review:
@@ -99,6 +104,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         node-version: [14, 16, 18, 20]
         os: [ubuntu-latest]

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail-fast:
+        description: 'Set the fail-fast strategey setting.'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dependency-review:
@@ -97,6 +102,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         node-version: [14, 16, 18, 20]
         os: [ubuntu-latest]

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
       auto-merge-exclude:
-        description: 'A semicolon seperated list of packages that you do not want to be auto-merged.'
+        description: 'A semicolon separated list of packages that you do not want to be auto-merged.'
         required: false
         default: 'fastify'
         type: string
+      fail-fast:
+        description: 'Set to false to disable the fail-fast strategy.'
+        required: false
+        default: true
+        type: boolean
       license-check:
         description: 'Check licenses.'
         required: false
         type: boolean
         default: false
       license-check-allowed-additional:
-        description: 'A semicolon seperated list of additional licenses to allow.'
+        description: 'A semicolon separated list of additional licenses to allow.'
         required: false
         type: string
         default: ''
@@ -22,11 +27,6 @@ on:
         description: 'Set to true to run linting scripts.'
         required: false
         default: false
-        type: boolean
-      fail-fast:
-        description: 'Set the fail-fast strategey setting.'
-        required: false
-        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
       auto-merge-exclude:
-        description: 'A semicolon seperated list of packages that you do not want to be auto-merged.'
+        description: 'A semicolon separated list of packages that you do not want to be auto-merged.'
         required: false
         default: 'fastify'
         type: string
+      fail-fast:
+        description: 'Set to false to disable the fail-fast strategy.'
+        required: false
+        default: true
+        type: boolean
       license-check:
-        description: 'Check licenses'
+        description: 'Check licenses.'
         required: false
         type: boolean
         default: false
       license-check-allowed-additional:
-        description: 'A semicolon seperated list of additional licenses to allow.'
+        description: 'A semicolon separated list of additional licenses to allow.'
         required: false
         type: string
         default: ''
@@ -22,11 +27,6 @@ on:
         description: 'Set to true to run linting scripts.'
         required: false
         default: false
-        type: boolean
-      fail-fast:
-        description: 'Set the fail-fast strategey setting.'
-        required: false
-        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail-fast:
+        description: 'Set the fail-fast strategey setting.'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dependency-review:
@@ -95,6 +100,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         node-version: [14, 16, 18, 20]
         db: [5, 6, 7]

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -4,17 +4,22 @@ on:
   workflow_call:
     inputs:
       auto-merge-exclude:
-        description: 'A semicolon seperated list of packages that you do not want to be auto-merged.'
+        description: 'A semicolon separated list of packages that you do not want to be auto-merged.'
         required: false
         default: 'fastify'
         type: string
+      fail-fast:
+        description: 'Set to false to disable the fail-fast strategy.'
+        required: false
+        default: true
+        type: boolean
       license-check:
         description: 'Check licenses.'
         required: false
         type: boolean
         default: false
       license-check-allowed-additional:
-        description: 'A semicolon seperated list of additional licenses to allow.'
+        description: 'A semicolon separated list of additional licenses to allow.'
         required: false
         type: string
         default: ''
@@ -22,11 +27,6 @@ on:
         description: 'Set to true to run linting scripts.'
         required: false
         default: false
-        type: boolean
-      fail-fast:
-        description: 'Set the fail-fast strategey setting.'
-        required: false
-        default: true
         type: boolean
 
 jobs:

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -97,6 +97,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         node-version: [14, 16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail-fast:
+        description: 'Set the fail-fast strategey setting.'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dependency-review:
@@ -97,7 +102,7 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         node-version: [14, 16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
 | Input Name                         | Required   | Type    | Default   | Description                                                                        |
 | ---------------------------------- | ---------- | ------- | --------- | ---------------------------------------------------------------------------------- |
 | `auto-merge-exclude`               | false      | string  | `fastify` | Provide a semicolon separated list of packages that you do not want to be auto-merged. |
+| `fail-fast`                        | false      | boolean | `true`    | Set to `false` to disable the fail-fast strategy. |
 | `license-check`                    | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
 | `license-check-allowed-additional` | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
 | `lint`                             | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |


### PR DESCRIPTION
When trying to debug CI errors in the matrix, its really frustrating to have to uncover them randomly one at a time. Can we change this so that all environments run to completion so its easier to find where problems live?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
