### PR TITLE
feat!: drop node@14 support for mongodb@6 driver

### DIFF
--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -98,7 +98,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [16, 18, 20]
         os: [ubuntu-latest]
         db: [5]
 


### PR DESCRIPTION
Refs https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0
Refs https://github.com/fastify/fastify-mongodb/pull/219

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
