### PR TITLE
docs: add permissions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
     with:
       lint: true


### PR DESCRIPTION
Adding the `permissions` config.

New repos (or just me??) do not allow permessive github token:

<img width="833" alt="image" src="https://github.com/fastify/workflows/assets/11404065/5955d449-afcd-4122-8132-af4122988179">

So these `permissions` are necessary to avoid the error:

```
[Invalid workflow file: .github/workflows/ci.yml#L14](https://github.com/Eomm/fastify-telegram/actions/runs/6449305117/workflow)
The workflow is not valid. .github/workflows/ci.yml (Line: 14, Col: 3): Error calling workflow 'fastify/workflows/.github/workflows/plugins-ci.yml@v3'. The nested job 'automerge' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.
```