### PR TITLE
chore: add node21 to the test matrix

### DIFF
--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -98,7 +98,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14, 16, 18, 20, 21]
         os: [ubuntu-latest]
         db: [5]
 

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -100,7 +100,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14, 16, 18, 20, 21]
         os: [ubuntu-latest]
         db: ['mysql:8.0']
 

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, 21]
         os: [ubuntu-latest]
         pnpm-version: [8]
         # pnpm@8 does not support Node.js 14 so include it separately

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -98,7 +98,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14, 16, 18, 20, 21]
         os: [ubuntu-latest]
         db: ['postgres:11-alpine']
 

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14, 16, 18, 20, 21]
         db: [5, 6, 7]
         exclude:
           - os: windows-latest

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -98,7 +98,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [14, 16, 18, 20, 21]
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
Node 21 got released. We should also test against node 21 to ensure we detect breaking changes early.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
