### PR TITLE
fix(plugins-ci-redis): remove exclusion of windows node 14

### DIFF
--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -98,7 +98,6 @@ jobs:
       matrix:
         node-version: [14, 16, 18, 20, 21]
         db: [5, 6, 7]
-
     services:
       redis:
         image: redis:${{ matrix.db }}

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -98,9 +98,7 @@ jobs:
       matrix:
         node-version: [14, 16, 18, 20, 21]
         db: [5, 6, 7]
-        exclude:
-          - os: windows-latest
-            node-version: 14
+
     services:
       redis:
         image: redis:${{ matrix.db }}


### PR DESCRIPTION
Resolves CI errors in fastify-redis: https://github.com/fastify/fastify-redis/actions/runs/6668185090/workflow

We only test on ubuntu anyway in this workflow, so the exclusion is redundant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
