### PR TITLE
docs(contributing): add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are welcome and any help that can be offered is greatly appreciated.
+Please take a moment to read the entire contributing guide.
+
+This repository uses the [Feature Branch Workflow](https://atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
+meaning that development should take place in `feat/` branches, with the `main` branch kept in a stable state.
+When you submit pull requests, please make sure to fork from and submit back to `main`.
+
+Other processes and specifications that are in use in this repository are:
+
+-   [Semantic versioning](https://semver.org/)
+-   [Conventional commits](https://conventionalcommits.org/en/v1.0.0/) following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+
+## Documentation style
+
+Documentation (both in markdown files and inline comments) should be written in **American English** where possible.
+
+Titles and headings should use sentence-style capitalization, where only the first letter of a sentence and proper nouns are capitalized.
+
+## Release process
+
+To create a release, run the [`release` workflow](https://github.com/fastify/workflows/actions/workflows/release.yml) by clicking the "Run workflow" button,
+and entering the release type (major, minor, or patch) into the presented input field.
+
+This will create a new branch and a pull request to `main` with the changes required to bump the version number.
+
+This method should be used for all releases as it also rebases tags. For example, if you release `v4.0.1` then the `v4` and `v4.0` tags are automatically updated to the new commit (or created if they don't exist).
+
+## Issues
+
+Please file your issues [here](https://github.com/fastify/workflows/issues) and try to provide as much information in the template as possible/relevant.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Past sponsors:
 
 -   [Yeovil District Hospital NHS Foundation Trust](https://yeovilhospital.co.uk/)
 
+## Contributing
+
+Contributions are welcome, and any help is greatly appreciated!
+
+See [the contributing guide](./CONTRIBUTING.md) for details on how to get started.
+Please adhere to Fastify's [Code of Conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md) when contributing.
+
 ## License
 
 Licensed under [MIT](./LICENSE).


### PR DESCRIPTION
Closes #109

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
