### PR TITLE
Make node versions dynamic

### DIFF
--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -7,6 +7,11 @@ on:
         type: string
         default: benchmark
         required: false
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   benchmark:
@@ -24,7 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -32,7 +32,7 @@ on:
         default: ${{ github.event.pull_request.base.ref }}
         required: false
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -54,7 +54,6 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout ${{ inputs.pr-repo }}@${{ inputs.pr-ref }}
         uses: actions/checkout@v4
@@ -97,8 +96,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   output-benchmark:
-    needs:
-      - benchmark
+    needs: benchmark
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -32,7 +32,7 @@ on:
         default: ${{ github.event.pull_request.base.ref }}
         required: false
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string
@@ -40,7 +40,7 @@ on:
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     outputs:
@@ -54,6 +54,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [ubuntu-latest]
     steps:
       - name: Checkout ${{ inputs.pr-repo }}@${{ inputs.pr-ref }}
         uses: actions/checkout@v4

--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -54,7 +54,6 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [ubuntu-latest]
     steps:
       - name: Checkout ${{ inputs.pr-repo }}@${{ inputs.pr-ref }}
         uses: actions/checkout@v4

--- a/.github/workflows/plugins-benchmark-pr.yml
+++ b/.github/workflows/plugins-benchmark-pr.yml
@@ -36,6 +36,7 @@ on:
         required: false
         default: '["18", "20", "21"]'
         type: string
+
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -96,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: ${{ fromJson(inputs.node-versions) }}
     services:
       zookeeper:
         image: 'confluentinc/cp-zookeeper:7.4.3'

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -98,13 +98,12 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
         db: [5]
 
     services:

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -105,7 +105,6 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
         db: [5]
-
     services:
       mongo:
         image: mongo:${{ matrix.db }}

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -98,8 +103,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
-        os: [ubuntu-latest]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
         db: [5]
 
     services:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -100,8 +105,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
-        os: [ubuntu-latest]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
         db: ['mysql:8.0']
 
     services:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -107,7 +107,6 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
         db: ['mysql:8.0']
-
     services:
       mysql:
         image: ${{ matrix.db }}

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -100,13 +100,12 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
         db: ['mysql:8.0']
 
     services:

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         pnpm-version: [8]
 
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -2,6 +2,12 @@ name: Plugin CI - Package Managers
 
 on:
   workflow_call:
+    inputs:
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   pnpm:
@@ -11,8 +17,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
-        os: [ubuntu-latest]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
         pnpm-version: [8]
 
     steps:
@@ -44,8 +50,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
-        os: [ubuntu-latest]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -105,7 +105,6 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
         db: ['postgres:11-alpine']
-
     services:
       postgres:
         image: ${{ matrix.db }}

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -98,13 +98,12 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
         db: ['postgres:11-alpine']
 
     services:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -98,8 +103,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
-        os: [ubuntu-latest]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
         db: ['postgres:11-alpine']
 
     services:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -102,7 +102,6 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        os: [macos-latest, ubuntu-latest, windows-latest]
         db: [5, 6, 7]
     services:
       redis:

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -96,7 +101,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: ${{ fromJson(inputs.node-versions) }}
+        os: [macos-latest, ubuntu-latest, windows-latest]
         db: [5, 6, 7]
     services:
       redis:

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -29,7 +29,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
+        description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -29,7 +29,7 @@ on:
         default: false
         type: boolean
       node-versions:
-        description: 'A comma-separated list of Node versions to test against.'
+        description: 'A stringified JSON array that specifies the Node.js versions on which the job should run.'
         required: false
         default: '["18", "20", "21"]'
         type: string

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: false
         type: boolean
+      node-versions:
+        description: 'A comma-separated list of Node versions to test against.'
+        required: false
+        default: '["18", "20", "21"]'
+        type: string
 
 jobs:
   dependency-review:
@@ -103,7 +108,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: ${{ fromJson(inputs.node-versions) }}
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Check out repo

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
 | `license-check`                      | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
 | `license-check-allowed-additional`   | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
 | `lint`                               | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
-| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the job should run.           |
+| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide A JSON array that specifies the Node.js versions on which the job should run.           |
 
 ## Benchmark PR workflow
 
@@ -112,7 +112,7 @@ jobs:
 | Input Name                         | Required   | Type    | Default     | Description                                                                        |
 | ---------------------------------- | ---------- | ------- | ----------- | ---------------------------------------------------------------------------------- |
 | `npm-script`                       | false      | string  | `benchmark` | Provide the name of the npm script to run                                       |
-| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the job should run.           |
+| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide A JSON array that specifies the Node.js versions on which the job should run.           |
 
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ jobs:
 
 | Input Name                         | Required   | Type    | Default   | Description                                                                        |
 | ---------------------------------- | ---------- | ------- | --------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude`               | false      | string  | `fastify` | Provide a semicolon separated list of packages that you do not want to be auto-merged. |
-| `license-check`                    | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
-| `license-check-allowed-additional` | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
-| `lint`                             | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| `auto-merge-exclude`                 | false      | string  | `fastify` | Provide a semicolon separated list of packages that you do not want to be auto-merged. |
+| `license-check`                      | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
+| `license-check-allowed-additional`   | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
+| `lint`                               | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
+| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the tests should run.           |
 
 ## Benchmark PR workflow
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ jobs:
 
   remove-label:
     if: "always()"
-    needs: 
-      - benchmark
+    needs: benchmark
     runs-on: ubuntu-latest
     steps:
       - name: Remove benchmark label

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
 | `license-check`                      | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
 | `license-check-allowed-additional`   | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
 | `lint`                               | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
-| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the tests should run.           |
+| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the job should run.           |
 
 ## Benchmark PR workflow
 
@@ -112,6 +112,7 @@ jobs:
 | Input Name                         | Required   | Type    | Default     | Description                                                                        |
 | ---------------------------------- | ---------- | ------- | ----------- | ---------------------------------------------------------------------------------- |
 | `npm-script`                       | false      | string  | `benchmark` | Provide the name of the npm script to run                                       |
+| `node-versions`                      | false      | string  | `'["18", "20", "21"]'`   | Provide a stringified JSON array that specifies the Node.js versions on which the job should run.           |
 
 
 ## Acknowledgements


### PR DESCRIPTION
This will let us use the centralized workflow for most _libraries_

Examples of where it will be used if merged:

https://github.com/fastify/proxy-addr/pull/61#pullrequestreview-2003940510
https://github.com/fastify/fluent-json-schema/pull/242
https://github.com/fastify/process-warning/pull/104

and other `@fastify/libraries` repos