### PR TITLE
chore(backport): exclude Node 14 and 16 on macos (#127)

### DIFF
--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -6,20 +6,18 @@ on:
 jobs:
   pnpm:
     name: pnpm
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: [16, 18, 20, 21]
-        os: [ubuntu-latest]
         pnpm-version: [8]
         # pnpm@8 does not support Node.js 14 so include it separately
         include:
           - node-version: 14
             os: ubuntu-latest
             pnpm-version: 7
-
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -44,13 +42,12 @@ jobs:
 
   yarn:
     name: Yarn
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: [14, 16, 18, 20]
-        os: [ubuntu-latest]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -108,6 +108,10 @@ jobs:
         exclude:
           - os: windows-latest
             node-version: 14
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 16
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
* chore: exclude Node 14 and 16 on macos

Related to https://github.com/fastify/.github/issues/37.

This is just a proposal, probably not comprehensive of all the places where a similar change may have to occur, simply to capture that this is possible (and I didn't know until now) to exclude combinations, as documented in https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations



* remove os matrix from package

---------

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
