### PR TITLE
chore: extract elasticsearch image version

### DIFF
--- a/.github/workflows/plugins-ci-elasticsearch.yml
+++ b/.github/workflows/plugins-ci-elasticsearch.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: 'fastify'
         type: string
+      elasticsearch-version:
+        description: 'The version of Elasticsearch to use.'
+        required: true
+        default: '8.15.2'
+        type: string
       license-check:
         description: 'Check licenses'
         required: false
@@ -104,7 +109,7 @@ jobs:
         node-version: ${{ fromJson(inputs.node-versions) }}
     services:
       elasticsearch:
-        image: elasticsearch:8.15.2
+        image: elasticsearch:${{ inputs.elasticsearch-version }}
         ports:
           - '9200:9200'
           - '9300:9300'


### PR DESCRIPTION
In order to avoid tagging new versions of this repository whenever a new version of elasticsearch image is released or doesn't exist anymore on Docker Hub, extracts the image version as a workflow input.

This will allow driving the version being used from https://github.com/fastify/fastify-elasticsearch/blob/master/.github/workflows/ci.yml directly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] ~run `npm run test` and `npm run benchmark`~ no test and benchmarks
- [x] ~tests and/or benchmarks are included~ no tests
- [x] ~documentation is changed or added~ no documentation
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
