### PR TITLE
feat: add option to disallow code generation from strings

### DIFF
--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: '["20", "22"]'
         type: string
+      check-disallow-code-generation-from-strings:
+        description: 'Enables --disallow-code-generation-from-strings flag for Node.js'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   dependency-review:
@@ -110,12 +115,23 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
         os: [macos-latest, ubuntu-latest, windows-latest]
+        disallow-code-generation-from-strings: ${{ inputs.check-disallow-code-generation-from-strings == true && ['true', 'false'] || ['false'] }}
         exclude:
           - os: macos-latest
             node-version: 14
           - os: macos-latest
             node-version: 16
     steps:
+      - name: Set node flags
+        id: node-flags
+        shell: bash
+        run: |
+          if [ "${{ matrix.disallow-code-generation-from-strings }}" = "true" ]; then
+            echo "flags=--disallow-code-generation-from-strings" >> $GITHUB_OUTPUT
+          else
+            echo "flags=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check out repo
         uses: actions/checkout@v4
         with:
@@ -130,7 +146,7 @@ jobs:
         run: npm i --ignore-scripts
 
       - name: Run tests
-        run: npm test
+        run: NODE_OPTIONS="${{ steps.node-flags.outputs.flags }}" npm test
 
   fastify-dependency-integration:
     name: Test Fastify Integration

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ jobs:
 
 ### Inputs
 
-| Input Name                         | Required   | Type    | Default   | Description                                                                        |
-| ---------------------------------- | ---------- | ------- | --------- | ---------------------------------------------------------------------------------- |
-| `auto-merge-exclude`                 | false      | string  | `fastify` | Provide a semicolon separated list of packages that you do not want to be auto-merged. |
-| `fastify-dependency-integration`     | false      | boolean | `false`   | Set to `true` to run fastify tests with the (proposed) changes. |
-| `license-check`                      | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
-| `license-check-allowed-additional`   | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
-| `lint`                               | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
-| `node-versions`                      | false      | string  | `'["20", "22"]'`   | Provide A JSON array that specifies the Node.js versions on which the job should run.           |
+| Input Name                                    | Required | Type    | Default          | Description                                                                                                                                            |
+|-----------------------------------------------|----------|---------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `auto-merge-exclude`                          | false    | string  | `fastify`        | Provide a semicolon separated list of packages that you do not want to be auto-merged.                                                                 |
+| `fastify-dependency-integration`              | false    | boolean | `false`          | Set to `true` to run fastify tests with the (proposed) changes.                                                                                        |
+| `license-check`                               | false    | boolean | `false`          | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
+| `license-check-allowed-additional`            | false    | string  |                  | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow.                                                    |
+| `lint`                                        | false    | boolean | `false`          | Set to `true` to run the `lint` script in a repository's `package.json`.                                                                               |
+| `node-versions`                               | false    | string  | `'["20", "22"]'` | Provide A JSON array that specifies the Node.js versions on which the job should run.                                                                  |
+| `check-disallow-code-generation-from-strings` | false    | boolean | `false`          | Enables --disallow-code-generation-from-strings flag for Node.js                                                                                       |
 
 ## Benchmark PR workflow
 


### PR DESCRIPTION
`eval` and `new Function` is not available on platforms such as Cloudflare workers. This option will add support for disabling and testing environments where code generation from strings are not available.