### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-workflows-files.yml
+++ b/.github/workflows/validate-workflows-files.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - '.github/workflows/*.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174