### PR TITLE
ci: ignore scripts

### DIFF
--- a/.github/workflows/plugins-ci-elasticsearch.yml
+++ b/.github/workflows/plugins-ci-elasticsearch.yml
@@ -98,7 +98,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm i
+        run: npm i --ignore-scripts
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm i
+        run: npm i --ignore-scripts
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm i
+        run: npm i --ignore-scripts
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -37,7 +37,7 @@ jobs:
           version: ${{ matrix.pnpm-version }}
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Run tests
         run: pnpm run test
@@ -65,7 +65,7 @@ jobs:
       - name: Install with Yarn
         run: |
           curl -o- -L https://yarnpkg.com/install.sh | bash
-          yarn install --ignore-engines
+          yarn install --ignore-engines --ignore-scripts
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm i
+        run: npm i --ignore-scripts
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm i
+        run: npm i --ignore-scripts
 
       - name: Lint code
         run: npm run lint


### PR DESCRIPTION
Add the `--ignore-scripts` arg to disable the execution of any scripts by third-party packages.

See https://snyk.io/blog/npm-security-preventing-supply-chain-attacks/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
