### PR TITLE
refactor: move linting, dep checks, and license checks to own workflow

### DIFF
--- a/.github/workflows/plugins-ci-elasticsearch.yml
+++ b/.github/workflows/plugins-ci-elasticsearch.yml
@@ -35,77 +35,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }}
+    needs: quality-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -30,77 +30,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }}
+    needs: quality-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -30,78 +30,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    needs: quality-check
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -30,80 +30,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        if: ${{ inputs.lint == true}}
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    needs: quality-check
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -30,78 +30,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    needs: quality-check
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/plugins-ci-quality.yml
+++ b/.github/workflows/plugins-ci-quality.yml
@@ -1,0 +1,94 @@
+name: Plugin CI - Quality
+
+# **What it does**: Runs dependency review, license checks, and linting for plugins.
+# **Why we have it**: Used by other workflows to ensure code quality and compliance.
+
+on:
+  workflow_call:
+    inputs:
+      license-check:
+        description: 'Check licenses.'
+        required: false
+        type: boolean
+        default: false
+      license-check-allowed-additional:
+        description: 'A semicolon seperated list of additional licenses to allow.'
+        required: false
+        type: string
+        default: ''
+      lint:
+        description: 'Set to true to run linting scripts.'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+
+  license-check:
+    if: >
+      !failure() &&
+      !cancelled() &&
+      inputs.license-check == true
+    name: Check Licenses
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          check-latest: true
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm i --ignore-scripts
+
+      - name: Check Licenses
+        env:
+          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
+        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
+
+  linter:
+    name: Lint Code
+    if: >
+      !failure() &&
+      !cancelled() &&
+      inputs.lint == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          check-latest: true
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm i --ignore-scripts
+
+      - name: Lint code
+        run: npm run lint

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -30,78 +30,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    needs: quality-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -35,78 +35,19 @@ on:
         type: string
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+  quality-check:
+    uses: ./.github/workflows/plugins-ci-quality.yml
     permissions:
       contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-
-  license-check:
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.license-check == true
-    name: Check Licenses
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Check Licenses
-        env:
-          ALLOWED_ADDITIONAL: ${{ inputs.license-check-allowed-additional }}
-        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;$ALLOWED_ADDITIONAL"
-
-  linter:
-    name: Lint Code
-    if: >
-      !failure() &&
-      !cancelled() &&
-      inputs.lint == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Lint code
-        run: npm run lint
+    secrets: inherit
+    with:
+      license-check: ${{ inputs.license-check }}
+      license-check-allowed-additional: ${{ inputs.license-check-allowed-additional }}
+      lint: ${{ inputs.lint }}
 
   test:
     name: Test
+    needs: quality-check
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -143,6 +84,7 @@ jobs:
 
   fastify-dependency-integration:
     name: Test Fastify Integration
+    needs: quality-check
     runs-on: ubuntu-latest
     if: >
       !failure() &&


### PR DESCRIPTION
Closes #70.

Cuts down on duplicate steps across workflows. Now if we need to amend linting and quality check steps we can just update one workflow instead of multiple.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
