### PR TITLE
ci: bump elasticsearch, mongo and postgres versions in workflows

### DIFF
--- a/.github/workflows/plugins-ci-elasticsearch.yml
+++ b/.github/workflows/plugins-ci-elasticsearch.yml
@@ -11,7 +11,7 @@ on:
       elasticsearch-version:
         description: 'The version of Elasticsearch to use.'
         required: true
-        default: '8.15.2'
+        default: '9.3.0'
         type: string
       license-check:
         description: 'Check licenses'

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        db: [5]
+        db: [8]
     services:
       mongo:
         image: mongo:${{ matrix.db }}

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        db: ['postgres:11-alpine']
+        db: ['postgres:18-alpine']
     services:
       postgres:
         image: ${{ matrix.db }}


### PR DESCRIPTION
Proposal:

Update the versions of the following Docker images:
- `Elasticsearch`: `8.15.2` → `9.3.0`
- `MongoDB`: `5` → `8`
- `PostgreSQL`: `11-alpine` → `18-alpine`

See reference here: https://github.com/fastify/fastify-citgm/pull/113 and comment here: https://github.com/fastify/fastify-citgm/pull/113#discussion_r2935535850