### PR TITLE
ci!: add node 26 to default node-versions test matrices

### DIFF
--- a/.github/workflows/plugins-ci-elasticsearch.yml
+++ b/.github/workflows/plugins-ci-elasticsearch.yml
@@ -31,7 +31,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-kafka.yml
+++ b/.github/workflows/plugins-ci-kafka.yml
@@ -26,7 +26,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -26,7 +26,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -26,7 +26,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-package-manager.yml
+++ b/.github/workflows/plugins-ci-package-manager.yml
@@ -6,7 +6,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -26,7 +26,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -26,7 +26,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -31,7 +31,7 @@ on:
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
-        default: '["20", "22", "24"]'
+        default: '["20", "22", "24", "26"]'
         type: string
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
 | `license-check`                      | false      | boolean | `false`   | Set to `true` to check that a repository's production dependencies use permissive licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, or ISC. |
 | `license-check-allowed-additional`   | false      | string  |           | Provide a semicolon separated list of SPDX-license identifiers that you want to additionally allow. |
 | `lint`                               | false      | boolean | `false`   | Set to `true` to run the `lint` script in a repository's `package.json`.           |
-| `node-versions`                      | false      | string  | `'["20", "22", "24"]'`   | Provide A JSON array that specifies the Node.js versions on which the job should run.           |
+| `node-versions`                      | false      | string  | `'["20", "22", "24", "26"]'`   | Provide A JSON array that specifies the Node.js versions on which the job should run.           |
 
 ## Acknowledgments
 


### PR DESCRIPTION
BREAKING CHANGE: Node 26 added to default node-version test matrices.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
