### PR TITLE
docs: fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,14 @@
 Contributions are welcome and any help that can be offered is greatly appreciated.
 Please take a moment to read the entire contributing guide.
 
-This repository uses the [Feature Branch Workflow](https://atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
+This repository uses the [Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
 meaning that development should take place in `feat/` branches, with the `main` branch kept in a stable state.
 When you submit pull requests, please make sure to fork from and submit back to `main`.
 
 Other processes and specifications that are in use in this repository are:
 
 -   [Semantic versioning](https://semver.org/)
--   [Conventional commits](https://conventionalcommits.org/en/v1.0.0/) following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+-   [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
 
 ## Documentation style
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Reusable workflows for use in the Fastify organization.
 
 ## Intro
 
-GitHub [introduced reusable workflows](https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/) on 2021-11-29 which, as the name suggests, are workflows that can be referenced across the entirety of GitHub. A reusable workflow is called by using the `uses` keyword in another workflow.
+GitHub [introduced reusable workflows](https://github.blog/news-insights/product-news/github-actions-reusable-workflows-is-generally-available/) on 2021-11-29 which, as the name suggests, are workflows that can be referenced across the entirety of GitHub. A reusable workflow is called by using the `uses` keyword in another workflow.
 
-For more information, including limitations, [see the GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows).
+For more information, including limitations, [see the GitHub Docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows).
 
 ## CI workflows
 ### Usage
@@ -92,7 +92,7 @@ jobs:
 
 Past sponsors:
 
--   [Yeovil Hospital](https://somersetft.nhs.uk/yeovilhospital/)
+-   [Yeovil Hospital](https://www.somersetft.nhs.uk/yeovilhospital/)
 
 ## Contributing
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71