### PR TITLE
build(dependabot): correct prefix for gha; add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
     - package-ecosystem: github-actions
       commit-message:
           include: scope
-          prefix: build
+          prefix: ci
+      cooldown:
+          default-days: 7
+          include:
+              - "*"
       directory: /
       groups:
           github-owned:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
           prefix: ci
       cooldown:
           default-days: 7
-          include:
-              - "*"
       directory: /
       groups:
           github-owned:


### PR DESCRIPTION
Added cooldown config for GHA updates to protect us a teeny bit supply chain side.
Also corrected the prefix for dependabot PRs for GHA updates, [should be ci as per Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
