### PR TITLE
ci(plugins-ci): require quality-checks to pass

### DIFF
--- a/.github/workflows/plugins-ci.yml
+++ b/.github/workflows/plugins-ci.yml
@@ -120,6 +120,7 @@ jobs:
     name: Automerge Dependabot PRs
     if: >
       always() &&
+      needs.quality-check.result == 'success' &&
       needs.test.result == 'success' &&
       (needs.fastify-dependency-integration.result == 'success' || needs.fastify-dependency-integration.result == 'skipped') &&
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
[`always()` overrides the results of the `needs` array](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-not-requiring-successful-dependent-jobs
), so even though linting failed in https://github.com/fastify/busboy/pull/220, the automerge still occurred. `always()` is used so fastify-dependency-integration can be skipped if not enabled.

Spotted thanks to @Tony133 in https://github.com/fastify/busboy/pull/221



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
