### PR TITLE
ci: add redis v8.x to test matrix

### DIFF
--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        db: [5, 6, 7]
+        db: [5, 6, 7, 8]
     services:
       redis:
         image: redis:${{ matrix.db }}


### PR DESCRIPTION
Proposal:

- Add `Redis` v8.x to the CI test matrix.

Note:

- Release v8.x: https://github.com/redis/redis/releases/tag/8.0.0