### PR TITLE
ci(workflows): parameterize MySQL and PostgreSQL versions

### DIFF
--- a/.github/workflows/plugins-ci-mysql.yml
+++ b/.github/workflows/plugins-ci-mysql.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      mysql-version:
+        description: 'The version of MySQL to use.'
+        required: false
+        default: '8.0'
+        type: string
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
@@ -42,17 +47,16 @@ jobs:
       lint: ${{ inputs.lint }}
 
   test:
-    name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    name: Node.js ${{ matrix.node-version }} - MySQL ${{ inputs.mysql-version }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        db: ['mysql:8.0']
     services:
       mysql:
-        image: ${{ matrix.db }}
+        image: mysql:${{ inputs.mysql-version }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
           MYSQL_DATABASE: mysql

--- a/.github/workflows/plugins-ci-postgres.yml
+++ b/.github/workflows/plugins-ci-postgres.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      postgresql-version:
+        description: 'The version of PostgreSQL to use.'
+        required: false
+        default: '18'
+        type: string
       node-versions:
         description: 'A JSON array that specifies the Node.js versions on which the job should run.'
         required: false
@@ -42,17 +47,16 @@ jobs:
       lint: ${{ inputs.lint }}
 
   test:
-    name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    name: Node.js ${{ matrix.node-version }} - PostgreSQL ${{ inputs.postgresql-version }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions) }}
-        db: ['postgres:18-alpine']
     services:
       postgres:
-        image: ${{ matrix.db }}
+        image: postgres:${{ inputs.postgresql-version }}-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres


### PR DESCRIPTION
Proposal:

- Adds optional version inputs to the MySQL and PostgreSQL plugin CI workflows.
  - MySQL defaults to version 8.0
  - PostgreSQL defaults to version 18
  - The database version can now be overridden by plugin workflows
  - Maintains current behavior for existing consumers
  - PostgreSQL versions older than 17 are not supported

- This allows individual plugins to test additional database versions, if needed, following the same pattern already used by the Elasticsearch CI workflow.
- We currently support Elasticsearch versions 8 and 9 in the Elasticsearch plugin for backward compatibility.

Note:

- This prepares shared workflows for testing new major database versions without changing the default version for existing consumers.
- Individual plugins can explicitly test a newer database version when needed.