### PR TITLE
ci: clarify Redis version in job name

### DIFF
--- a/.github/workflows/plugins-ci-redis.yml
+++ b/.github/workflows/plugins-ci-redis.yml
@@ -42,7 +42,7 @@ jobs:
       lint: ${{ inputs.lint }}
 
   test:
-    name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    name: Node.js ${{ matrix.node-version }} - Redis ${{ matrix.db }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Proposal:

- Adds the word "Redis" to the job name in the test matrix.
- The GitHub Actions check list currently shows job names like `Node.js 20 - 5` ( see screenshot ), which doesn't make clear that `5` refers to the Redis version being tested. This makes the checks harder to read at a glance, especially in the PR checks list.

<img width="801" height="186" alt="CI- Redis" src="https://github.com/user-attachments/assets/22c6a902-c95c-4501-88af-6b261929ddc9" />

Changes:

- Before: `Node.js 20 - 5`
- After: `Node.js 20 - Redis 5`

Note:

- Single line change in the workflow `name:` field, no functional impact.


