### PR TITLE
ci: clarify MongoDB version in job name

### DIFF
--- a/.github/workflows/plugins-ci-mongo.yml
+++ b/.github/workflows/plugins-ci-mongo.yml
@@ -42,7 +42,7 @@ jobs:
       lint: ${{ inputs.lint }}
 
   test:
-    name: Node.js ${{ matrix.node-version }} - ${{ matrix.db }}
+    name: Node.js ${{ matrix.node-version }} - MongoDB ${{ matrix.db }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Proposal:

- Adds the word "MongoDB" to the job name in the test matrix.
- The GitHub Actions check list currently shows job names like `Node.js 24 - 8`, which doesn't make clear that `8` refers to the MongoDB version being tested. This makes the checks harder to read at a glance, especially in the PR checks list.

Changes:
- Before: `Node.js 24 - 8`
- After: `Node.js 24 - MongoDB 8`

Note:

- Single line change in the workflow `name:` field, no functional impact.


Related: follow-up to #233, as requested by @Fdawgs 👀